### PR TITLE
Add fixes to account for changes to the api

### DIFF
--- a/cypress/e2e/dashboard_spec.cy.js
+++ b/cypress/e2e/dashboard_spec.cy.js
@@ -14,31 +14,31 @@ describe('Homepage Test', () => {
       cy.get('.movie-card').should('have.length', 4)
     })
   })
-  it('Should show the Money Plane card', () => {
+  it('Should show the Black Adam card', () => {
     cy.get('.movies-container').within(() => {
-      cy.get('.movie-card').eq(0).should('contain', 'Money Plane')
-        .and('contain', '6.7')
+      cy.get('.movie-card').eq(0).should('contain', 'Black Adam')
+        .and('contain', '4')
       cy.get('.poster').eq(0).should('be.visible')
     })
   })
-  it('Should show the Mulan card', () => {
+  it('Should show the The Woman King card', () => {
     cy.get('.movies-container').within(() => {
-      cy.get('.movie-card').eq(1).should('contain', 'Mulan')
-        .and('contain', '4.9')
+      cy.get('.movie-card').eq(1).should('contain', 'The Woman King')
+        .and('contain', '4')
       cy.get('.poster').eq(1).should('be.visible')
     })
   })
-  it('Should show the Rogue card', () => {
+  it('Should show the R.I.P.D. 2: Rise of the Damned card', () => {
     cy.get('.movies-container').within(() => {
-      cy.get('.movie-card').eq(2).should('contain', 'Rogue')
-        .and('contain', '5.4')
+      cy.get('.movie-card').eq(2).should('contain', 'R.I.P.D. 2: Rise of the Damned')
+        .and('contain', '7')
       cy.get('.poster').eq(2).should('be.visible')
     })
   })
-  it('Should show the Ava card', () => {
+  it('Should show the Black Panther: Wakanda Forever card', () => {
     cy.get('.movies-container').within(() => {
-      cy.get('.movie-card').eq(3).should('contain', 'Ava')
-      .and('contain', '5.1')
+      cy.get('.movie-card').eq(3).should('contain', 'Black Panther: Wakanda Forever')
+      .and('contain', '4')
       cy.get('.poster').eq(3).should('be.visible')
     })
   })
@@ -46,24 +46,24 @@ describe('Homepage Test', () => {
     cy.intercept(
       {
         method: "POST",
-        url: "http://localhost:3000/movies/337401",
+        url: "http://localhost:3000/movies/724495",
       },
       {
-        id: 337401,
-        title: "Mulan",
+        id: 724495,
+        title: "The Woman King",
         backdrop_path:
-          "https://image.tmdb.org/t/p/original//zzWGRw277MNoCs3zhyG3YmYQsXv.jpg",
-        release_date: "2020-09-04",
+          "https://image.tmdb.org/t/p/original//7zQJYV02yehWrQN6NjKsBorqUUS.jpg",
+        release_date: "2022-09-15",
         overview:
-          "When the Emperor of China issues a decree that one man per family must serve in the Imperial Chinese Army to defend the country from Huns, Hua Mulan, the eldest daughter of an honored warrior, steps in to take the place of her ailing father. She is spirited, determined and quick on her feet. Disguised as a man by the name of Hua Jun, she is tested every step of the way and must harness her innermost strength and embrace her true potential.",
-        genres: ["Action", "Adventure", "Drama", "Fantasy"],
-        budget: 200000000,
-        revenue: 57000000,
-        runtime: 115,
-        tagline: "",
-        average_rating: 5.1,
+          "The story of the Agojie, the all-female unit of warriors who protected the African Kingdom of Dahomey in the 1800s with skills and a fierceness unlike anything the world has ever seen, and General Nanisca as she trains the next generation of recruits and readies them for battle against an enemy determined to destroy their way of life.",
+        genres: ["Action", "Drama", "History"],
+        budget: 50000000,
+        revenue: 91000000,
+        runtime: 135,
+        tagline: "Her reign begins.",
+        average_rating: 4,
       }
-    ).get('.movie-card').eq(1).click().url().should('include', '/337401')
+    ).get('.movie-card').eq(1).click().url().should('include', '/724495')
   });
 })
 

--- a/cypress/e2e/single_movie_spec.cy.js
+++ b/cypress/e2e/single_movie_spec.cy.js
@@ -1,45 +1,44 @@
 describe('Single Movie Test', () => {
     beforeEach(() => {
-        cy.visit('http://localhost:3000/539885');
+        cy.visit('http://localhost:3000/436270');
       })
     it('Should have a title', () => {
         cy.contains('h1', 'Putrid Pepinos')
-        cy.contains('h1', 'Ava')
+        cy.contains('h1', 'Black Adam')
     })
     it('Should display an Overview', () => {
         cy.get('.movie-details').should('contain', 'Overview')
-            .and('contain', 'assassin')
+            .and('contain', 'Nearly 5,000 years after he was bestowed with the almighty powers of the Egyptian gods—and imprisoned just as quickly—Black Adam is freed from his earthly tomb, ready to unleash his unique form of justice on the modern world.')
     })
     it('Should display Genres', () => {
         cy.get('.movie-details').should('contain', 'Genres')
             .and('contain', 'Action')
-            .and('contain', 'Crime')
-            .and('contain', 'Drama')
-            .and('contain', 'Thriller')
+            .and('contain', 'Fantasy')
+            .and('contain', 'Science Fiction')
     })
     it('Should display a Budget', () => {
         cy.get('.movie-details').should('contain', 'Budget')
-            .and('contain', '$0')
+            .and('contain', '$200000000')
     })
     it('Should display a Revenue', () => {
         cy.get('.movie-details').should('contain', 'Revenue')
-            .and('contain', '$152812')
+            .and('contain', '$384571691')
     })
     it('Should display a Runtime', () => {
         cy.get('.movie-details').should('contain', 'Runtime')
-            .and('contain', '96 minutes')
+            .and('contain', '125 minutes')
     })
     it('Should display a Tagline', () => {
         cy.get('.movie-details').should('contain', 'Tagline')
-            .and('contain', 'Kill. Or be killed.')
+            .and('contain', 'The world needed a hero. It got Black Adam.')
     })
     it('Should display a Release Date', () => {
         cy.get('.movie-details').should('contain', 'Release Date')
-            .and('contain', '2020-07-02')
+            .and('contain', '2022-10-19')
     })
     it('Should display a Rating', () => {
         cy.get('.movie-details').should('contain', 'Rating')
-            .and('contain', '5.9')
+            .and('contain', '4')
     })
     it('Should display both images ', () => {
         cy.get('.movie-details').within(() => {

--- a/cypress/fixtures/movies.json
+++ b/cypress/fixtures/movies.json
@@ -1,35 +1,35 @@
  { "movies": [
   {
-    "id": 694919,
-    "poster_path": "https://image.tmdb.org/t/p/original//6CoRTJTmijhBLJTUNoVSUNxZMEI.jpg",
-    "backdrop_path": "https://image.tmdb.org/t/p/original//pq0JSpwyT2URytdFG0euztQPAyR.jpg",
-    "title": "Money Plane",
-    "average_rating": 6.666666666666667,
-    "release_date": "2020-09-29"
-  },
-  {
-    "id": 337401,
-    "poster_path": "https://image.tmdb.org/t/p/original//aKx1ARwG55zZ0GpRvU2WrGrCG9o.jpg",
-    "backdrop_path": "https://image.tmdb.org/t/p/original//zzWGRw277MNoCs3zhyG3YmYQsXv.jpg",
-    "title": "Mulan",
-    "average_rating": 4.909090909090909,
-    "release_date": "2020-09-04"
-  },
-  {
-    "id": 718444,
-    "poster_path": "https://image.tmdb.org/t/p/original//uOw5JD8IlD546feZ6oxbIjvN66P.jpg",
-    "backdrop_path": "https://image.tmdb.org/t/p/original//x4UkhIQuHIJyeeOTdcbZ3t3gBSa.jpg",
-    "title": "Rogue",
-    "average_rating": 5.428571428571429,
-    "release_date": "2020-08-20"
-  },
-  {
-    "id": 539885,
-    "poster_path": "https://image.tmdb.org/t/p/original//qzA87Wf4jo1h8JMk9GilyIYvwsA.jpg",
-    "backdrop_path": "https://image.tmdb.org/t/p/original//54yOImQgj8i85u9hxxnaIQBRUuo.jpg",
-    "title": "Ava",
-    "average_rating": 5.111111111111111,
-    "release_date": "2020-07-02"
-  }
+    "id": 436270,
+    "poster_path": "https://image.tmdb.org/t/p/original//pFlaoHTZeyNkG83vxsAJiGzfSsa.jpg",
+    "backdrop_path": "https://image.tmdb.org/t/p/original//bQXAqRx2Fgc46uCVWgoPz5L5Dtr.jpg",
+    "title": "Black Adam",
+    "average_rating": 4,
+    "release_date": "2022-10-19"
+    },
+    {
+    "id": 724495,
+    "poster_path": "https://image.tmdb.org/t/p/original//438QXt1E3WJWb3PqNniK0tAE5c1.jpg",
+    "backdrop_path": "https://image.tmdb.org/t/p/original//7zQJYV02yehWrQN6NjKsBorqUUS.jpg",
+    "title": "The Woman King",
+    "average_rating": 4,
+    "release_date": "2022-09-15"
+    },
+    {
+    "id": 1013860,
+    "poster_path": "https://image.tmdb.org/t/p/original//g4yJTzMtOBUTAR2Qnmj8TYIcFVq.jpg",
+    "backdrop_path": "https://image.tmdb.org/t/p/original//kmzppWh7ljL6K9fXW72bPN3gKwu.jpg",
+    "title": "R.I.P.D. 2: Rise of the Damned",
+    "average_rating": 7,
+    "release_date": "2022-11-15"
+    },
+    {
+    "id": 505642,
+    "poster_path": "https://image.tmdb.org/t/p/original//ps2oKfhY6DL3alynlSqY97gHSsg.jpg",
+    "backdrop_path": "https://image.tmdb.org/t/p/original//xDMIl84Qo5Tsu62c9DGWhmPI67A.jpg",
+    "title": "Black Panther: Wakanda Forever",
+    "average_rating": 4,
+    "release_date": "2022-11-09"
+    }
 ]
 }


### PR DESCRIPTION
Since the original movies API went down, when it came back up I noticed the movies were different as well as the ID's and such. I changed our data for cypress to match the new movie data from the API. 